### PR TITLE
Fixing test de integración contínua dentro del proyecto 

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "998930e4482b67d469d6e672d9c3e33f6b6370287384a75df316b00b5d8e5958"
+            "sha256": "774a679401e642b6e9586cce45f05bfd60d1cf593cb828355f5fc4015de351a2"
         },
         "pipfile-spec": 6,
         "requires": {},

--- a/fib.py
+++ b/fib.py
@@ -8,6 +8,8 @@ Los números negativos no son aceptados
 def fibonacci(position):
   if(position < 0):
     raise ValueError("Invalid input")
+  if(position == 0):
+    return 0
   if(position == 1 or position == 2):
     return 1
   return fibonacci(position - 1) + fibonacci(position - 2)


### PR DESCRIPTION
## Cambios implementados
Luego de correr las pruebas se evidenció que el problema en los logs especificaba:
```bash
Your Pipfile.lock 
(998930e4482b67d469d6e672d9c3e33f6b6370287384a75df316b00b5d8e5958) is out of 
date. Expected: 
(774a679401e642b6e9586cce45f05bfd60d1cf593cb8[28](https://github.com/AnyaMarcanito/lab4-software/actions/runs/11746347915/job/32725895372#step:5:29)355f5fc4015de351a2).
```
por lo que en el archivo Pipfile.lock se cambió la línea 4  para agregar `774a679401e642b6e9586cce45f05bfd60d1cf593cb8` en el atributo de `sha256` dentro de `hash`.

Luego de esto, el error pasó a ser:

![image](https://github.com/user-attachments/assets/4177ad7b-aeff-4af4-a64d-95cf4d449a31)

Por lo cual se modificó el archivo `fib.py` en el que no estaba definido el caso base, por lo que fue agregado con un condicional en la línea 11, que se encarga de retornar el valor cero para el caso en que la variable position es cero.

## Pruebas realizadas

Se corrieron las pruebas por medio de:
`pipenv install --deploy --dev`
`pipenv run pytest`

y al subir tanto la rama como pushear los cambios dentro de github los test fueron corridos obteniendo los siguientes resultados:

![image](https://github.com/user-attachments/assets/0a6cde2d-e1a7-4d5b-a246-f0d1f3143e7f)
