### PR TITLE
Standarization usando black formatter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,6 @@ jobs:
       - name: Run test suite
         run: |
           pipenv run pytest
+      - name: Run black formatter
+        uses: rickstaa/action-black@v1.3.3
+  

--- a/Pipfile
+++ b/Pipfile
@@ -5,3 +5,6 @@ name = "pypi"
 
 [packages]
 pytest="7.2.0"
+
+[dev-packages]
+black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "998930e4482b67d469d6e672d9c3e33f6b6370287384a75df316b00b5d8e5958"
+            "sha256": "774a679401e642b6e9586cce45f05bfd60d1cf593cb828355f5fc4015de351a2"
         },
         "pipfile-spec": 6,
         "requires": {},

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "774a679401e642b6e9586cce45f05bfd60d1cf593cb828355f5fc4015de351a2"
+            "sha256": "6222ea00240a19b4e23c578b944ab021ff5264daebf21bfa465e38a18d4e6385"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -191,11 +191,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
-                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.1"
+            "version": "==24.2"
         },
         "pathspec": {
             "hashes": [
@@ -237,6 +237,22 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==6.0.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38",
+                "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.0.2"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.12.2"
         }
     }
 }

--- a/fib.py
+++ b/fib.py
@@ -8,6 +8,8 @@ Los números negativos no son aceptados
 def fibonacci(position):
   if(position < 0):
     raise ValueError("Invalid input")
+  if(position == 0):
+    return 0
   if(position == 1 or position == 2):
     return 1
   return fibonacci(position - 1) + fibonacci(position - 2)

--- a/fib.py
+++ b/fib.py
@@ -5,11 +5,12 @@ El número cero en la secuencia de Fibonacci es 0. El primer número es 1
 Los números negativos no son aceptados
 """
 
+
 def fibonacci(position):
-  if(position < 0):
-    raise ValueError("Invalid input")
-  if(position == 0):
-    return 0
-  if(position == 1 or position == 2):
-    return 1
-  return fibonacci(position - 1) + fibonacci(position - 2)
+    if position < 0:
+        raise ValueError("Invalid input")
+    if position == 0:
+        return 0
+    if position == 1 or position == 2:
+        return 1
+    return fibonacci(position - 1) + fibonacci(position - 2)

--- a/tests/test_fib.py
+++ b/tests/test_fib.py
@@ -1,5 +1,10 @@
 from fib import fibonacci
 
+
 # Casos de prueba para la función de Fibonacci
-def test_first_fibonacci(): assert(fibonacci(1) == 1)
-def test_zero_fibonacci(): assert(fibonacci(0) == 0)
+def test_first_fibonacci():
+    assert fibonacci(1) == 1
+
+
+def test_zero_fibonacci():
+    assert fibonacci(0) == 0


### PR DESCRIPTION
## Cambios implementados
En el main.yml fue agregado 
```bash
      - name: Run black formatter
        uses: rickstaa/action-black@v1.3.3
```
y fueron seguidos los pasos descritos en el `Paso 3: Haz que tu código luzca bonito` del README.md del repositorio para que se mejorara la estructura del código.

## Pruebas realizadas

Al subir tanto la rama como pushear los cambios dentro de github los test fueron corridos obteniendo los siguientes resultados:

![image](https://github.com/user-attachments/assets/30675506-b678-4377-b599-d2805749d45a)

